### PR TITLE
linux_rpc_demo: do not include rsc_table.h

### DIFF
--- a/apps/examples/linux_rpc_demo/linux_rpc_demo.c
+++ b/apps/examples/linux_rpc_demo/linux_rpc_demo.c
@@ -19,7 +19,6 @@
 #include <unistd.h>
 #include <openamp/open_amp.h>
 #include <openamp/rpmsg_rpc_client_server.h>
-#include "rsc_table.h"
 #include "platform_info.h"
 #include "linux-rpmsg-rpc-demo.h"
 

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -315,6 +315,8 @@ static void rpmsg_virtio_release_rx_buffer(struct rpmsg_device *rdev,
 	/* Return buffer on virtqueue. */
 	len = virtqueue_get_buffer_length(rvdev->rvq, idx);
 	rpmsg_virtio_return_buffer(rvdev, rp_hdr, len, idx);
+	/* tell peer we return some rx buffer */
+	virtqueue_kick(rvdev->rvq);
 	metal_mutex_release(&rdev->lock);
 }
 


### PR DESCRIPTION
No symbols from rsc_table.h are used in linux_rpc_demo.c and the demo fails to build. Remove include rsc_table.h.

Signed-off-by: Sergei Korneichuk <sergei.korneichuk@amd.com>