### PR TITLE
rpmsg_virtio.c: replace metal_cpu_yield to new libmetal API metal_yield

### DIFF
--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -12,7 +12,7 @@
 #include <openamp/remoteproc.h>
 #include <openamp/remoteproc_virtio.h>
 #include <openamp/virtqueue.h>
-#include <metal/cpu.h>
+#include <metal/sys.h>
 #include <metal/utilities.h>
 #include <metal/alloc.h>
 
@@ -412,6 +412,6 @@ void rproc_virtio_wait_remote_ready(struct virtio_device *vdev)
 		status = rproc_virtio_get_status(vdev);
 		if (status & VIRTIO_CONFIG_STATUS_DRIVER_OK)
 			return;
-		metal_cpu_yield();
+		metal_yield();
 	}
 }

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -10,6 +10,7 @@
 
 #include <metal/alloc.h>
 #include <metal/sleep.h>
+#include <metal/sys.h>
 #include <metal/utilities.h>
 #include <openamp/rpmsg_virtio.h>
 #include <openamp/virtqueue.h>
@@ -271,8 +272,7 @@ static int rpmsg_virtio_wait_remote_ready(struct rpmsg_virtio_device *rvdev)
 		} else if (status & VIRTIO_CONFIG_STATUS_DRIVER_OK) {
 			return 0;
 		}
-		/* TODO: clarify metal_cpu_yield usage*/
-		metal_cpu_yield();
+		metal_yield();
 	}
 }
 


### PR DESCRIPTION
The CPU yield is not supported by all OSes/processors. If not supported, this causes a busy loop that monopolizes the CPU. Replace it with the new metal_yield, it would be managed at the OS level and dispatched to metal_cpu_yield, metal_sleep_usec, or others.